### PR TITLE
Add hammer organization resources and tools for common operations

### DIFF
--- a/src/hammer_mcp_server/data/hammer_basic_information.md
+++ b/src/hammer_mcp_server/data/hammer_basic_information.md
@@ -15,6 +15,7 @@ To get help for any hammer command, use:
 
 ## Common Subcommands
 - `hammer lifecycle-environment` - See the `hammer_lifecycle_environment_docs` resource for more information
+- `hammer organization` - See the `hammer_organization_docs` resource for more information
 
 ## Examples
 - `hammer --help` - Display all possible subcommands

--- a/src/hammer_mcp_server/data/hammer_organization_annotated_help.md
+++ b/src/hammer_mcp_server/data/hammer_organization_annotated_help.md
@@ -1,0 +1,306 @@
+# Hammer Organization Information
+What follows is the output of various `hammer organization --help` commands (as of 2025-11-11),
+demonstrating the flags each `hammer organization` action takes as parameters.
+
+## `hammer organization`
+This subcommand can be executed with any actions and parameters using the `execute_hammer` tool.
+Example `hammer organization --help`
+```
+$ hammer organization --help
+Usage:
+    hammer organization [OPTIONS] SUBCOMMAND [ARG] ...
+
+Parameters:
+ SUBCOMMAND                    Subcommand
+ [ARG] ...                     Subcommand arguments
+
+Subcommands:
+ add-compute-resource          Associate a compute resource
+ add-domain                    Associate a domain
+ add-hostgroup                 Associate a hostgroup
+ add-location                  Associate a location
+ add-medium                    Associate a medium
+ add-provisioning-template     Associate provisioning templates
+ add-smart-proxy               Associate a smart proxy
+ add-subnet                    Associate a subnet
+ add-user                      Associate an user
+ configure-cdn                 Update the CDN configuration
+ create                        Create organization
+ delete                        Delete an organization
+ delete-parameter              Delete parameter for an organization
+ info                          Show organization
+ list                          List all organizations
+ remove-compute-resource       Disassociate a compute resource
+ remove-domain                 Disassociate a domain
+ remove-hostgroup              Disassociate a hostgroup
+ remove-location               Disassociate a location
+ remove-medium                 Disassociate a medium
+ remove-provisioning-template  Disassociate provisioning templates
+ remove-smart-proxy            Disassociate a smart proxy
+ remove-subnet                 Disassociate a subnet
+ remove-user                   Disassociate an user
+ set-parameter                 Create or update parameter for an organization
+ update                        Update organization
+
+Options:
+ -h, --help                    Print help
+```
+
+## `hammer organization list`
+This subcommand can be executed using the `execute_hammer` tool, or via the `hammer://generate-organization-list` and `hammer://execute-organization-list` resources.
+```
+$ hammer organization list --help
+Usage:
+    hammer organization <list|index> [OPTIONS]
+
+Options:
+ --fields LIST                                  Show specified fields or predefined field sets only. (See below)
+ --full-result BOOLEAN                          Whether or not to show all results
+ --location[-id|-title] VALUE/NUMBER            Set the current location context for the request
+ --order VALUE                                  Sort field and order, eg. 'id DESC'
+ --organization[-id|-title|-label] VALUE/NUMBER Set the current organization context for the request
+ --page NUMBER                                  Page number, starting at 1
+ --per-page NUMBER                              Number of results per page to return
+ --search VALUE                                 Search string
+ --sort-by VALUE                                Field to sort the results on
+ --sort-order VALUE                             How to order the sorted results (e.g. ASC for ascending)
+ -h, --help                                     Print help
+
+Predefined field sets:
+  ------------|-----|---------|-----
+  FIELDS      | ALL | DEFAULT | THIN
+  ------------|-----|---------|-----
+  Id          | x   | x       | x
+  Title       | x   | x       | x
+  Name        | x   | x       | x
+  Description | x   | x       |
+  Label       | x   | x       | x
+  ------------|-----|---------|-----
+
+Option details:
+  Here you can find option types and the value an option can accept:
+
+  BOOLEAN             One of true/false, yes/no, 1/0
+  DATETIME            Date and time in YYYY-MM-DD HH:MM:SS or ISO 8601 format
+  ENUM                Possible values are described in the option's description
+  FILE                Path to a file
+  KEY_VALUE_LIST      Comma-separated list of key=value.
+                      JSON is acceptable and preferred way for such parameters
+  LIST                Comma separated list of values. Values containing comma should be quoted or escaped with backslash.
+                      JSON is acceptable and preferred way for such parameters
+  MULTIENUM           Any combination of possible values described in the option's description
+  NUMBER              Numeric value. Integer
+  SCHEMA              Comma separated list of values defined by a schema.
+                      JSON is acceptable and preferred way for such parameters
+  VALUE               Value described in the option's description. Mostly simple string
+
+Search / Order fields:
+  description         text
+  id                  integer
+  label               string
+  name                string
+  organization_id     integer
+  title               string
+```
+
+## `hammer organization info`
+This subcommand can be executed using the `execute_hammer` tool, or via the `hammer://generate-organization-info/{name}` and `hammer://execute-organization-info/{name}` resources.
+```
+$ hammer organization info --help
+Usage:
+    hammer organization <info|show> [OPTIONS]
+
+Options:
+ --fields LIST                                  Show specified fields or predefined field sets only. (See below)
+ --id VALUE
+ --label VALUE                                  Organization label to search by
+ --location[-id|-title] VALUE/NUMBER            Set the current location context for the request
+ --name VALUE                                   Set the current organization context for the request
+ --organization[-id|-title|-label] VALUE/NUMBER Set the current organization context for the request
+ --title VALUE                                  Set the current organization context for the request
+ -h, --help                                     Print help
+
+Predefined field sets:
+  -------------------------------------------------|-----|---------|-----
+  FIELDS                                           | ALL | DEFAULT | THIN
+  -------------------------------------------------|-----|---------|-----
+  Id                                               | x   | x       | x
+  Title                                            | x   | x       | x
+  Name                                             | x   | x       | x
+  Description                                      | x   | x       |
+  Parent                                           | x   | x       |
+  Users/                                           | x   | x       |
+  Smart proxies/                                   | x   | x       |
+  Subnets/                                         | x   | x       |
+  Compute resources/                               | x   | x       |
+  Installation media/                              | x   | x       |
+  Templates/                                       | x   | x       |
+  Partition tables/                                | x   | x       |
+  Domains/                                         | x   | x       |
+  Realms/                                          | x   | x       |
+  Hostgroups/                                      | x   | x       |
+  Parameters/                                      | x   | x       |
+  Locations/                                       | x   | x       |
+  Created at                                       | x   | x       |
+  Updated at                                       | x   | x       |
+  Label                                            | x   | x       | x
+  Description                                      | x   | x       |
+  Service levels                                   | x   | x       |
+  Cdn configuration/type                           | x   | x       |
+  Cdn configuration/url                            | x   | x       |
+  Cdn configuration/upstream organization          | x   | x       |
+  Cdn configuration/upstream lifecycle environment | x   | x       |
+  Cdn configuration/upstream content view          | x   | x       |
+  Cdn configuration/username                       | x   | x       |
+  Cdn configuration/ssl ca credential id           | x   | x       |
+  -------------------------------------------------|-----|---------|-----
+
+Option details:
+  Here you can find option types and the value an option can accept:
+
+  BOOLEAN             One of true/false, yes/no, 1/0
+  DATETIME            Date and time in YYYY-MM-DD HH:MM:SS or ISO 8601 format
+  ENUM                Possible values are described in the option's description
+  FILE                Path to a file
+  KEY_VALUE_LIST      Comma-separated list of key=value.
+                      JSON is acceptable and preferred way for such parameters
+  LIST                Comma separated list of values. Values containing comma should be quoted or escaped with backslash.
+                      JSON is acceptable and preferred way for such parameters
+  MULTIENUM           Any combination of possible values described in the option's description
+  NUMBER              Numeric value. Integer
+  SCHEMA              Comma separated list of values defined by a schema.
+                      JSON is acceptable and preferred way for such parameters
+  VALUE               Value described in the option's description. Mostly simple string
+```
+
+## `hammer organization create`
+This subcommand can be executed using the `execute_hammer` tool, the `execute_hammer_organization_create` tool, or via the `hammer://generate-organization-create/{name}` resource.
+```
+$ hammer organization create --help
+Usage:
+    hammer organization create [OPTIONS]
+
+Options:
+ --compute-resource[s|-ids] LIST                Compute resource names/ids
+ --description VALUE
+ --domain[s|-ids] LIST                          Domain names/ids
+ --environment-ids LIST                         Environment ids
+ --hostgroup[s|-ids|-titles] LIST               Host group names/titles/ids
+ --ignore-types LIST                            List of resources types that will be automatically associated
+ --label VALUE
+ --location[-id|-title] VALUE/NUMBER            Set the current location context for the request
+ --location[s|-ids|-titles] LIST                Associated location names/titles/ids
+ --medi[a|um-ids] LIST                          Medium names/ids
+ --name VALUE
+ --organization[-id|-title|-label] VALUE/NUMBER Set the current organization context for the request
+ --partition-table[s|-ids] LIST                 Partition template names/ids
+ --provisioning-template[s|-ids] LIST           Provisioning template names/ids
+ --realm[s|-ids] LIST                           Realm names/ids
+ --smart-prox[ies|y-ids] LIST                   Smart proxy names/ids
+ --subnet[s|-ids] LIST                          Subnet names/ids
+ --user[s|-ids] LIST                            User logins/ids
+ -h, --help                                     Print help
+
+Option details:
+  Here you can find option types and the value an option can accept:
+
+  BOOLEAN             One of true/false, yes/no, 1/0
+  DATETIME            Date and time in YYYY-MM-DD HH:MM:SS or ISO 8601 format
+  ENUM                Possible values are described in the option's description
+  FILE                Path to a file
+  KEY_VALUE_LIST      Comma-separated list of key=value.
+                      JSON is acceptable and preferred way for such parameters
+  LIST                Comma separated list of values. Values containing comma should be quoted or escaped with backslash.
+                      JSON is acceptable and preferred way for such parameters
+  MULTIENUM           Any combination of possible values described in the option's description
+  NUMBER              Numeric value. Integer
+  SCHEMA              Comma separated list of values defined by a schema.
+                      JSON is acceptable and preferred way for such parameters
+  VALUE               Value described in the option's description. Mostly simple string
+```
+
+## `hammer organization update`
+This subcommand can be executed using the `execute_hammer` tool, the `execute_hammer_organization_update` tool, or via the `hammer://generate-organization-update/{name}/{new_name}/{description}` resource.
+```
+$ hammer organization update --help
+Usage:
+    hammer organization update [OPTIONS]
+
+Options:
+ --compute-resource[s|-ids] LIST                Compute resource names/ids
+ --description VALUE
+ --domain[s|-ids] LIST                          Domain names/ids
+ --environment-ids LIST                         Environment ids
+ --hostgroup[s|-ids|-titles] LIST               Host group names/titles/ids
+ --id VALUE
+ --ignore-types LIST                            List of resources types that will be automatically associated
+ --label VALUE                                  Organization label to search by
+ --location[-id|-title] VALUE/NUMBER            Set the current location context for the request
+ --location[s|-ids|-titles] LIST                Associated location names/titles/ids
+ --medi[a|um-ids] LIST                          Medium names/ids
+ --name VALUE
+ --new-name VALUE
+ --new-title VALUE
+ --organization[-id|-title|-label] VALUE/NUMBER Set the current organization context for the request
+ --partition-table[s|-ids] LIST                 Partition template names/ids
+ --provisioning-template[s|-ids] LIST           Provisioning template names/ids
+ --realm[s|-ids] LIST                           Realm names/ids
+ --redhat-repository-url VALUE                  Red Hat CDN URL
+ --smart-prox[ies|y-ids] LIST                   Smart proxy names/ids
+ --subnet[s|-ids] LIST                          Subnet names/ids
+ --title VALUE                                  Set the current organization context for the request
+ --user[s|-ids] LIST                            User logins/ids
+ -h, --help                                     Print help
+
+Option details:
+  Here you can find option types and the value an option can accept:
+
+  BOOLEAN             One of true/false, yes/no, 1/0
+  DATETIME            Date and time in YYYY-MM-DD HH:MM:SS or ISO 8601 format
+  ENUM                Possible values are described in the option's description
+  FILE                Path to a file
+  KEY_VALUE_LIST      Comma-separated list of key=value.
+                      JSON is acceptable and preferred way for such parameters
+  LIST                Comma separated list of values. Values containing comma should be quoted or escaped with backslash.
+                      JSON is acceptable and preferred way for such parameters
+  MULTIENUM           Any combination of possible values described in the option's description
+  NUMBER              Numeric value. Integer
+  SCHEMA              Comma separated list of values defined by a schema.
+                      JSON is acceptable and preferred way for such parameters
+  VALUE               Value described in the option's description. Mostly simple string
+```
+
+## `hammer organization delete`
+This subcommand can be executed using the `execute_hammer` tool, the `execute_hammer_organization_delete` tool, or via the `hammer://generate-organization-delete/{name}` resource.
+```
+$ hammer organization delete --help
+Usage:
+    hammer organization <delete|destroy> [OPTIONS]
+
+Options:
+ --async                                        Do not wait for the task
+ --id VALUE
+ --label VALUE                                  Organization label to search by
+ --location[-id|-title] VALUE/NUMBER            Set the current location context for the request
+ --name VALUE                                   Set the current organization context for the request
+ --organization[-id|-title|-label] VALUE/NUMBER Set the current organization context for the request
+ --title VALUE                                  Set the current organization context for the request
+ -h, --help                                     Print help
+
+Option details:
+  Here you can find option types and the value an option can accept:
+
+  BOOLEAN             One of true/false, yes/no, 1/0
+  DATETIME            Date and time in YYYY-MM-DD HH:MM:SS or ISO 8601 format
+  ENUM                Possible values are described in the option's description
+  FILE                Path to a file
+  KEY_VALUE_LIST      Comma-separated list of key=value.
+                      JSON is acceptable and preferred way for such parameters
+  LIST                Comma separated list of values. Values containing comma should be quoted or escaped with backslash.
+                      JSON is acceptable and preferred way for such parameters
+  MULTIENUM           Any combination of possible values described in the option's description
+  NUMBER              Numeric value. Integer
+  SCHEMA              Comma separated list of values defined by a schema.
+                      JSON is acceptable and preferred way for such parameters
+  VALUE               Value described in the option's description. Mostly simple string
+```

--- a/src/hammer_mcp_server/resources/hammer_docs.py
+++ b/src/hammer_mcp_server/resources/hammer_docs.py
@@ -26,6 +26,24 @@ def register_hammer_docs(mcp):
             return f"error: Failed to read Hammer CLI basic information: {str(e)}"
 
     @mcp.resource(
+        name="Hammer Organization Command Documentation",
+        description="Comprehensive documentation for hammer organization commands including list, info, create, update, and delete operations with examples and usage patterns.",
+        uri="hammer://organization-annotated-help-docs",
+        mime_type="text/markdown",
+    )
+    async def hammer_organization_info() -> str:
+        try:
+            data_path = files("hammer_mcp_server").joinpath(
+                "data/hammer_organization_annotated_help.md"
+            )
+            async with aiofiles.open(data_path) as f:
+                return await f.read()
+        except FileNotFoundError:
+            return "error: Hammer organization documentation file not found."
+        except Exception as e:
+            return f"error: Failed to read Hammer organization documentation: {str(e)}"
+
+    @mcp.resource(
         name="Hammer CLI Documentation Webpage",
         description="Provides access to Hammer CLI documentation from docs.theforeman.org. This resource contains information on nearly all Hammer CLI commands and their usage.",
         uri="hammer://web-documentation",

--- a/src/hammer_mcp_server/resources/hammer_resources.py
+++ b/src/hammer_mcp_server/resources/hammer_resources.py
@@ -4,6 +4,11 @@ from ..utils.hammer_utils import (
     lifecycle_environment_delete,
     lifecycle_environment_info,
     lifecycle_environment_list,
+    organization_create,
+    organization_delete,
+    organization_info,
+    organization_list,
+    organization_update,
 )
 
 
@@ -18,7 +23,7 @@ def register_hammer_resources(mcp):
         return await execute_hammer_command_for_resource("full-help")
 
     @mcp.resource(
-        name="Generate Hammer CLI Lifecycle Environment List",
+        name="Generate Hammer CLI Lifecycle Environment List Command",
         description="Generates a hammer command for listing lifecycle environments. Does not execute the command.",
         uri="hammer://generate-lifecycle-environment-list",
         mime_type="text/plain",
@@ -27,7 +32,7 @@ def register_hammer_resources(mcp):
         return f"hammer {lifecycle_environment_list()}"
 
     @mcp.resource(
-        name="Execute Hammer CLI Lifecycle Environment List",
+        name="Execute Hammer CLI Lifecycle Environment List Command",
         description="Executes the hammer command to list lifecycle environments and returns the output.",
         uri="hammer://execute-lifecycle-environment-list",
         mime_type="text/plain",
@@ -36,7 +41,7 @@ def register_hammer_resources(mcp):
         return await execute_hammer_command_for_resource(lifecycle_environment_list())
 
     @mcp.resource(
-        name="Generate Hammer CLI Lifecycle Environment Info",
+        name="Generate Hammer CLI Lifecycle Environment Info Command",
         description="Generates a hammer command for getting lifecycle environment information. Does not execute the command.",
         uri="hammer://generate-lifecycle-environment-info/{organization_name}/{lifecycle_environment_name}",
         mime_type="text/plain",
@@ -47,7 +52,7 @@ def register_hammer_resources(mcp):
         return f"hammer {lifecycle_environment_info(organization_name, lifecycle_environment_name)}"
 
     @mcp.resource(
-        name="Execute Hammer CLI Lifecycle Environment Info",
+        name="Execute Hammer CLI Lifecycle Environment Info Command",
         description="Executes the hammer command to get lifecycle environment information and returns the output.",
         uri="hammer://execute-lifecycle-environment-info/{organization_name}/{lifecycle_environment_name}",
         mime_type="text/plain",
@@ -60,7 +65,7 @@ def register_hammer_resources(mcp):
         )
 
     @mcp.resource(
-        name="Generate Hammer CLI Lifecycle Environment Create",
+        name="Generate Hammer CLI Lifecycle Environment Create Command",
         description="Generates a hammer command for creating a lifecycle environment. Does not execute the command.",
         uri="hammer://generate-lifecycle-environment-create/{organization_name}/{lifecycle_environment_name}/{prior_lifecycle_environment_name}",
         mime_type="text/plain",
@@ -73,7 +78,7 @@ def register_hammer_resources(mcp):
         return f"hammer {lifecycle_environment_create(organization_name, lifecycle_environment_name, prior_lifecycle_environment_name)}"
 
     @mcp.resource(
-        name="Generate Hammer CLI Lifecycle Environment Delete",
+        name="Generate Hammer CLI Lifecycle Environment Delete Command",
         description="Generates a hammer command for deleting a lifecycle environment. Does not execute the command.",
         uri="hammer://generate-lifecycle-environment-delete/{organization_name}/{lifecycle_environment_name}",
         mime_type="text/plain",
@@ -83,3 +88,68 @@ def register_hammer_resources(mcp):
         lifecycle_environment_name: str,
     ) -> str:
         return f"hammer {lifecycle_environment_delete(organization_name, lifecycle_environment_name)}"
+
+    @mcp.resource(
+        name="Generate Hammer Organization List Command",
+        description="Generates a hammer command for listing organizations. Does not execute the command.",
+        uri="hammer://generate-organization-list",
+        mime_type="text/plain",
+    )
+    async def generate_hammer_organization_list() -> str:
+        return f"hammer {organization_list()}"
+
+    @mcp.resource(
+        name="Execute Hammer CLI Organization List Command",
+        description="Executes the hammer command to list organizations and returns the output.",
+        uri="hammer://execute-organization-list",
+        mime_type="text/plain",
+    )
+    async def execute_hammer_organization_list() -> str:
+        return await execute_hammer_command_for_resource(organization_list())
+
+    @mcp.resource(
+        name="Generate Hammer Organization Info Command",
+        description="Generates a hammer command for getting organization information. Does not execute the command.",
+        uri="hammer://generate-organization-info/{name}",
+        mime_type="text/plain",
+    )
+    async def generate_hammer_organization_info(name: str) -> str:
+        return f"hammer {organization_info(name)}"
+
+    @mcp.resource(
+        name="Execute Hammer CLI Organization Info Command",
+        description="Executes the hammer command to get organization information and returns the output.",
+        uri="hammer://execute-organization-info/{name}",
+        mime_type="text/plain",
+    )
+    async def execute_hammer_organization_info(name: str) -> str:
+        return await execute_hammer_command_for_resource(organization_info(name))
+
+    @mcp.resource(
+        name="Generate Hammer Organization Create Command",
+        description="Generates a hammer command for creating an organization. Does not execute the command.",
+        uri="hammer://generate-organization-create/{name}",
+        mime_type="text/plain",
+    )
+    async def generate_hammer_organization_create(name: str) -> str:
+        return f"hammer {organization_create(name)}"
+
+    @mcp.resource(
+        name="Generate Hammer Organization Update Command",
+        description="Generates a hammer command for updating an organization. Does not execute the command.",
+        uri="hammer://generate-organization-update/{name}/{new_name}/{description}",
+        mime_type="text/plain",
+    )
+    async def generate_hammer_organization_update(
+        name: str, new_name: str = "", description: str = ""
+    ) -> str:
+        return f"hammer {organization_update(name, new_name, description)}"
+
+    @mcp.resource(
+        name="Generate Hammer Organization Delete Command",
+        description="Generates a hammer command for deleting an organization. Does not execute the command.",
+        uri="hammer://generate-organization-delete/{name}",
+        mime_type="text/plain",
+    )
+    async def generate_hammer_organization_delete(name: str) -> str:
+        return f"hammer {organization_delete(name)}"

--- a/src/hammer_mcp_server/tools/call_hammer_commands.py
+++ b/src/hammer_mcp_server/tools/call_hammer_commands.py
@@ -4,6 +4,9 @@ from ..utils.hammer_utils import (
     execute_hammer_command_for_tool,
     lifecycle_environment_create,
     lifecycle_environment_delete,
+    organization_create,
+    organization_delete,
+    organization_update,
 )
 
 
@@ -65,4 +68,51 @@ def register_hammer_commands(mcp):
         command = lifecycle_environment_delete(
             organization_name, lifecycle_environment_name
         )
+        return await execute_hammer_command_for_tool(command)
+
+    @mcp.tool(
+        description="Create a new organization in Foreman/Katello with the given name.",
+        tags=("hammer", "organization", "create", "destructive"),
+        annotations={
+            "title": "Execute Hammer CLI Organization Create",
+            "readOnlyHint": False,
+            "destructiveHint": True,
+            "idempotentHint": False,
+            "openWorldHint": False,
+        },
+    )
+    async def execute_hammer_organization_create(name: str) -> ToolResult:
+        command = organization_create(name)
+        return await execute_hammer_command_for_tool(command)
+
+    @mcp.tool(
+        description="Update an existing organization in Foreman/Katello. Can update name and/or description.",
+        tags=("hammer", "organization", "update", "destructive"),
+        annotations={
+            "title": "Execute Hammer CLI Organization Update",
+            "readOnlyHint": False,
+            "destructiveHint": True,
+            "idempotentHint": False,
+            "openWorldHint": False,
+        },
+    )
+    async def execute_hammer_organization_update(
+        name: str, new_name: str = "", description: str = ""
+    ) -> ToolResult:
+        command = organization_update(name, new_name, description)
+        return await execute_hammer_command_for_tool(command)
+
+    @mcp.tool(
+        description="Delete an organization from Foreman/Katello.",
+        tags=("hammer", "organization", "delete", "destructive"),
+        annotations={
+            "title": "Execute Hammer CLI Organization Delete",
+            "readOnlyHint": False,
+            "destructiveHint": True,
+            "idempotentHint": False,
+            "openWorldHint": False,
+        },
+    )
+    async def execute_hammer_organization_delete(name: str) -> ToolResult:
+        command = organization_delete(name)
         return await execute_hammer_command_for_tool(command)

--- a/src/hammer_mcp_server/utils/hammer_utils.py
+++ b/src/hammer_mcp_server/utils/hammer_utils.py
@@ -95,3 +95,34 @@ def lifecycle_environment_delete(
     organization_name: str, lifecycle_environment_name: str
 ) -> str:
     return f"lifecycle-environment delete --organization {shlex.quote(organization_name)} --name {shlex.quote(lifecycle_environment_name)}"
+
+
+# Organization utility functions
+def organization_list() -> str:
+    """Generate hammer organization list command."""
+    return "organization list"
+
+
+def organization_info(name: str) -> str:
+    """Generate hammer organization info command."""
+    return f"organization info --name {shlex.quote(name)}"
+
+
+def organization_create(name: str) -> str:
+    """Generate hammer organization create command."""
+    return f'organization create --name {shlex.quote(name)} --description "Created by Hammer MCP Server"'
+
+
+def organization_update(name: str, new_name: str = "", description: str = "") -> str:
+    """Generate hammer organization update command."""
+    cmd = f"organization update --name {shlex.quote(name)}"
+    if new_name:
+        cmd += f" --new-name {shlex.quote(new_name)}"
+    if description:
+        cmd += f" --description {shlex.quote(description)}"
+    return cmd
+
+
+def organization_delete(name: str) -> str:
+    """Generate hammer organization delete command."""
+    return f"organization delete --name {shlex.quote(name)}"


### PR DESCRIPTION
Adds support for `hammer organization` commands. 

Testing

1. Install and start the server:
`uv sync`
`uv run hammer-mcp-server --transport streamable-http`

2. Launch MCP Inspector:
`npx @modelcontextprotocol/inspector`
Connect to `http://localhost:8080/mcp` using "Streamable HTTP"

3. Verify the new resource appears:
    - hammer://organization-annotated-help-docs

4. Test executing organization commands through the execute_hammer tool
